### PR TITLE
Fix misuse of exchange types

### DIFF
--- a/lib/pub_sub_model_sync/service_rabbit.rb
+++ b/lib/pub_sub_model_sync/service_rabbit.rb
@@ -77,12 +77,12 @@ module PubSubModelSync
       service.start
       @channel = service.create_channel
       queue_settings = { durable: true, auto_delete: false }
-      @queue = channel.fanout(config.queue_name, queue_settings)
-      subscribe_to_topic
+      @queue = channel.queue(config.queue_name, queue_settings)
+      subscribe_to_exchange
     end
 
-    def subscribe_to_topic
-      @topic = channel.topic(config.topic_name)
+    def subscribe_to_exchange
+      @topic = channel.fanout(config.topic_name)
       queue.bind(topic, routing_key: queue.name)
     end
 

--- a/spec/service_rabbit_spec.rb
+++ b/spec/service_rabbit_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe PubSubModelSync::ServiceRabbit do
       expect(service).to receive(:create_channel).and_call_original
     end
     it 'subscribe to queue' do
-      expect(channel).to receive(:fanout).and_call_original
+      expect(channel).to receive(:queue).and_call_original
     end
-    it 'subscribe to topic' do
-      expect(channel).to receive(:topic).and_call_original
+    it 'subscribe to exchange' do
+      expect(channel).to receive(:fanout).and_call_original
     end
     it 'listening messages' do
       expect(channel.queue).to receive(:subscribe)
@@ -67,12 +67,12 @@ RSpec.describe PubSubModelSync::ServiceRabbit do
       attrs = { id: 10 }
       payload = { data: data, attributes: attrs }
       expected_args = [payload.to_json, hash_including(:routing_key, :type)]
-      expect(channel.topic).to receive(:publish).with(*expected_args)
+      expect(channel.fanout).to receive(:publish).with(*expected_args)
       inst.publish(data, attrs)
     end
     it 'print error when sending message' do
       error = 'Error msg'
-      expect(channel.topic).to receive(:publish).and_raise(error)
+      expect(channel.fanout).to receive(:publish).and_raise(error)
       allow(inst).to receive(:log)
       expect(inst).to receive(:log).with(include(error), :error)
       inst.publish('invalid data', {})


### PR DESCRIPTION
When using Rabbitmq, we have different types of exchanges depending on how do we want to route the messages. To have similar behaviors in the different message-brokers solutions, IMHO, we should:
1. Use fanout as the type of exchange to deliver the received message to all the different bound queues.
2. Assign a queue to each one of the different apps that want to subscribe (we should not let the user choose the name to avoid many apps subscribing to the same queue and therefore having a kind of race-condition for the messages).
3. Consider the wording we are using for `Topic` (is not the same for the three supported message-brokers). In Rabbitmq, `topic` is a kind of exchange and not something else you can subscribe to (that's the reason I suggest changing the method `subscribe_to_topic` if the idea is to use fanout. So, I'm not sure either if should we keep calling it a topic.

