### PR TITLE
Hotfix/fix missing ordering key ruby3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.6
 RUN apt-get update -qq
 WORKDIR /app
 COPY . /app

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'ruby-kafka' # kafka pub/sub
 
 group :test do
   gem 'database_cleaner-active_record'
-  gem 'sqlite3', '<= 1.3.13'
+  gem 'sqlite3', '~> 1.4'
 end
 
 # Specify your gem's dependencies in pub_sub_model_sync.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
     grpc (1.50.0)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
+    grpc (1.50.0-x86_64-linux)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
     grpc-google-iam-v1 (1.1.1)
       google-protobuf (~> 3.14)
       googleapis-common-protos (>= 1.3.12, < 2.0)
@@ -278,7 +281,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.4)
     strscan (3.0.5)
     thor (1.2.1)
     timeout (0.3.1)
@@ -304,7 +307,7 @@ DEPENDENCIES
   rspec
   rubocop (~> 1.6.0)
   ruby-kafka
-  sqlite3 (<= 1.3.13)
+  sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.3.9
+   2.4.5

--- a/gemfiles/Gemfile_6_2.6
+++ b/gemfiles/Gemfile_6_2.6
@@ -5,7 +5,7 @@ gem 'bunny' # rabbit-mq
 gem 'google-cloud-pubsub' # google pub/sub
 gem 'ruby-kafka' # kafka pub/sub
 gem 'rails', '~> 6'
-gem 'sqlite3', '~> 1.3', '< 1.4'
+gem 'sqlite3', '~> 1.4.4'
 
 group :test do
   gem 'database_cleaner-active_record'

--- a/lib/pub_sub_model_sync/service_google.rb
+++ b/lib/pub_sub_model_sync/service_google.rb
@@ -74,10 +74,10 @@ module PubSubModelSync
 
     def check_async_result(result, payload)
       log "Published message: #{payload.uuid} (via async)" if result.succeeded? && config.debug
-      unless result.succeeded?
-        log("Error publishing: #{[payload, result.error]} (via async)", :error)
-        config.on_error_publish.call(StandardError.new(result.error), { payload: payload })
-      end
+      return if result.succeeded?
+
+      log("Error publishing: #{[payload, result.error]} (via async)", :error)
+      config.on_error_publish.call(StandardError.new(result.error), { payload: payload })
     end
 
     # @param only_publish (Boolean): if false is used to listen and publish messages

--- a/lib/pub_sub_model_sync/service_google.rb
+++ b/lib/pub_sub_model_sync/service_google.rb
@@ -59,7 +59,7 @@ module PubSubModelSync
       raise if (retries += 1) > 1
 
       log("Resuming ordering_key and retrying OrderingKeyError for #{payload.uuid}: #{e.message}")
-      topic.resume_publish(payload.ordering_key, ordering_key: payload.ordering_key)
+      topic.resume_publish(payload.ordering_key)
       retry
     end
 

--- a/spec/service_google_spec.rb
+++ b/spec/service_google_spec.rb
@@ -120,14 +120,17 @@ RSpec.describe PubSubModelSync::ServiceGoogle do
   end
 
   describe '.publish' do
+    let(:exp_headers) { hash_including('service_model_sync' => true) }
+    let(:exp_settings) { hash_including(:ordering_key) }
+
     it 'deliveries message' do
-      expect(topic).to receive(:publish_async).with(payload.to_json, anything)
+      expect(topic).to receive(:publish_async).with(payload.to_json, exp_headers, exp_settings)
       inst.publish(payload)
     end
 
     it 'uses defined ordering_key as the :ordering_key' do
-      expected_hash = hash_including(ordering_key: payload.headers[:ordering_key])
-      expect(topic).to receive(:publish_async).with(anything, expected_hash)
+      expected_hash = hash_including(ordering_key: payload.ordering_key)
+      expect(topic).to receive(:publish_async).with(anything, anything, expected_hash)
       inst.publish(payload)
     end
 
@@ -143,7 +146,7 @@ RSpec.describe PubSubModelSync::ServiceGoogle do
       before { allow(inst.config).to receive(:sync_mode).and_return(true) }
 
       it 'uses defined ordering_key as the :ordering_key' do
-        expect(topic).to receive(:publish).with(payload.to_json, hash_including(:ordering_key))
+        expect(topic).to receive(:publish).with(payload.to_json, exp_headers, exp_settings)
         inst.publish(payload)
       end
     end


### PR DESCRIPTION
- [x] fix: reformat message headers to include ordering_key (google pubsub) 
         issue: ordering_key was missing in ruby3. Reason: ruby 3 has changed the named parameters behavior